### PR TITLE
⚡ Optimize akmods installation batching in kernel.sh

### DIFF
--- a/files/scripts/kernel.sh
+++ b/files/scripts/kernel.sh
@@ -348,22 +348,30 @@ function install_packages () {
   local akmod_dir="/tmp/akmods/kmods"
 
   # Install akmods
+  local install_rpmfusion="false"
+
   for akmod in ${AKMODS_WANTED[@]}; do
-    if [[ ! ${akmod} =~ "v4l2loopback" ]]; then
-      akmods+="${akmod_dir}/*${akmod}*.rpm"
-      dnf5 -y install /tmp/akmods/kmods/*${akmod}*.rpm
-    else
-      dnf5 -y install \
-          https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"${FEDORA_VERSION}".noarch.rpm \
-          https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"${FEDORA_VERSION}".noarch.rpm
-      dnf5 -y install \
-          v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
-      dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release
+    local found_files=("${akmod_dir}"/*"${akmod}"*.rpm)
+    akmods+=("${found_files[@]}")
+
+    if [[ ${akmod} =~ "v4l2loopback" ]]; then
+      install_rpmfusion="true"
+      akmods+=("v4l2loopback")
     fi
   done
 
-  if [[ ! ${#akmods[@]} -eq 0 ]]; then
-    dnf5 -y install ${akmods[@]}
+  if [[ "$install_rpmfusion" == "true" ]]; then
+      dnf5 -y install \
+          https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"${FEDORA_VERSION}".noarch.rpm \
+          https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"${FEDORA_VERSION}".noarch.rpm
+  fi
+
+  if [[ ${#akmods[@]} -gt 0 ]]; then
+    dnf5 -y install "${akmods[@]}"
+  fi
+
+  if [[ "$install_rpmfusion" == "true" ]]; then
+      dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release
   fi
 
   # Check if kernel version changed during installation

--- a/tests/test_kernel_install.sh
+++ b/tests/test_kernel_install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/bash
+
+# Mock environment
+export FEDORA_VERSION=40
+if [[ -z "${AKMODS_WANTED_STR:-}" ]]; then
+  AKMODS_WANTED=("xone" "v4l2loopback")
+else
+  # Split string into array
+  IFS=',' read -r -a AKMODS_WANTED <<< "$AKMODS_WANTED_STR"
+fi
+export KERNEL_PRE="6.8.0"
+
+# Counter for dnf5 calls
+DNF5_CALLS=0
+
+# Mock dnf5
+function dnf5() {
+  DNF5_CALLS=$((DNF5_CALLS+1))
+  echo "dnf5 called with: $@"
+}
+export -f dnf5
+
+# Mock rpm
+function rpm() {
+  if [[ "$1" == "-q" ]]; then
+    if [[ "$2" == "kernel" ]]; then
+      echo "kernel-6.8.0"
+    elif [[ "$2" == "kernel-tools" ]]; then
+      return 0 # installed
+    fi
+  elif [[ "$1" == "-E" ]]; then
+      echo "40"
+  fi
+}
+export -f rpm
+
+# Mock tree (used in list_packages but we don't care about it for benchmark, but script calls it)
+function tree() {
+  return 0
+}
+export -f tree
+
+# Setup files
+# Clean up first
+rm -rf /tmp/akmods /tmp/kernel-rpms
+
+mkdir -p /tmp/akmods/kmods
+mkdir -p /tmp/kernel-rpms
+touch /tmp/akmods/kmods/kmod-xone-1.0.rpm
+touch /tmp/akmods/kmods/kmod-v4l2loopback-1.0.rpm
+touch /tmp/kernel-rpms/kernel-core.rpm
+
+# Source the script
+source files/scripts/kernel.sh
+
+# Run install_packages
+echo "Running install_packages with AKMODS_WANTED=${AKMODS_WANTED[@]}"
+install_packages
+
+echo "Total dnf5 calls: $DNF5_CALLS"
+
+# Assertions
+if [[ "${#AKMODS_WANTED[@]}" -eq 2 ]]; then
+  # xone + v4l2loopback: 4 calls
+  if [[ "$DNF5_CALLS" -ne 4 ]]; then
+    echo "FAIL: Expected 4 calls, got $DNF5_CALLS"
+    exit 1
+  fi
+elif [[ "${#AKMODS_WANTED[@]}" -eq 1 ]]; then
+  # xone: 2 calls
+  if [[ "$DNF5_CALLS" -ne 2 ]]; then
+    echo "FAIL: Expected 2 calls, got $DNF5_CALLS"
+    exit 1
+  fi
+fi
+
+echo "PASS"


### PR DESCRIPTION
💡 **What:**
- Optimized `files/scripts/kernel.sh` `install_packages` function to collect all akmod packages into an array and install them in a single `dnf5` transaction.
- Handled `v4l2loopback` dependency (rpmfusion repos) by enabling them temporarily for the single transaction if needed.
- Fixed a bug where `akmods` array was being constructed as a concatenated string instead of array elements.
- Added `tests/test_kernel_install.sh` to verify the fix and prevent regression.

🎯 **Why:**
- The previous implementation called `dnf5 install` inside a loop for each akmod, which is inefficient (N+1 problem).
- For `v4l2loopback`, it performed multiple `dnf5` operations (install rpmfusion, install package, remove rpmfusion) separately.
- The `akmods` array accumulation was syntactically incorrect, leading to potential failures if multiple akmods were present (besides the one installed in the loop).

📊 **Measured Improvement:**
- Reduced `dnf5` calls from 6 to 4 in the default case (xone + v4l2loopback), a 33% reduction in total calls (or 40% reduction in akmod-related calls).
- For single akmod case (e.g., xone only), reduced `dnf5` calls from 3 to 2 (install kernel + install akmod), eliminating redundant installation attempts.

---
*PR created automatically by Jules for task [16308178309129942018](https://jules.google.com/task/16308178309129942018) started by @sukarn-m*