### PR TITLE
Test: Improve coverage for initial_sanity_check in kernel.sh

### DIFF
--- a/files/scripts/kernel.sh
+++ b/files/scripts/kernel.sh
@@ -227,7 +227,7 @@ function initial_sanity_check () {
     exit 1
   fi
 
-  if [[ ${#PREFERENCE_ORDER[@]} -eq 0 ]]; then
+  if [[ ! -v PREFERENCE_ORDER || ${#PREFERENCE_ORDER[@]} -eq 0 ]]; then
     echo "ERROR: PREFERENCE_ORDER not set."
     exit 1
   fi

--- a/tests/test_kernel.sh
+++ b/tests/test_kernel.sh
@@ -81,6 +81,35 @@ test_preference_order_empty() {
     fi
 }
 
+test_preference_order_unset() {
+    echo "Running test_preference_order_unset..."
+    (
+        # Mock command -v dnf5 to succeed
+        command() {
+            if [[ "$1" == "-v" && "$2" == "dnf5" ]]; then
+                echo "/usr/bin/dnf5"
+                return 0
+            fi
+            builtin command "$@"
+        }
+        source "$KERNEL_SH"
+        set +e
+        unset PREFERENCE_ORDER
+        output=$(initial_sanity_check 2>&1)
+        exit_code=$?
+        assert_eq "$exit_code" "1" || exit 1
+        assert_eq "$output" "ERROR: PREFERENCE_ORDER not set." || exit 1
+    )
+    local status=$?
+    if [[ $status -eq 0 ]]; then
+        echo -e "${GREEN}PASS: test_preference_order_unset${NC}"
+        ((passed++))
+    else
+        echo -e "${RED}FAIL: test_preference_order_unset (status $status)${NC}"
+        ((failed++))
+    fi
+}
+
 test_sanity_check_pass() {
     echo "Running test_sanity_check_pass..."
     (
@@ -110,6 +139,7 @@ test_sanity_check_pass() {
 
 test_dnf5_missing
 test_preference_order_empty
+test_preference_order_unset
 test_sanity_check_pass
 
 echo "----------------------------"


### PR DESCRIPTION
This PR improves testing coverage for `files/scripts/kernel.sh` by adding a test case to `tests/test_kernel.sh` that verifies `initial_sanity_check` handles an unset `PREFERENCE_ORDER` variable correctly.

It also fixes a bug in `files/scripts/kernel.sh` where checking the length of an unset array variable with `set -u` enabled caused a script crash. The fix involves checking if the variable is set before accessing its length.

Changes:
- Modified `tests/test_kernel.sh`: Added `test_preference_order_unset`.
- Modified `files/scripts/kernel.sh`: Added `[[ ! -v PREFERENCE_ORDER ... ]]` check in `initial_sanity_check`.


---
*PR created automatically by Jules for task [8918525780603683588](https://jules.google.com/task/8918525780603683588) started by @sukarn-m*