### PR TITLE
⚡ Parallelize curl downloads in fedora-atomic-repos.sh

### DIFF
--- a/files/scripts/fedora-atomic-repos.sh
+++ b/files/scripts/fedora-atomic-repos.sh
@@ -10,14 +10,30 @@ RPMFUSION_MIRROR_RPMS="https://mirrors.rpmfusion.org"
 
 mkdir -p /tmp/rpm-repos
 
-curl -Lo /tmp/rpm-repos/rpmfusion-free-release-"${RELEASE}".noarch.rpm "${RPMFUSION_MIRROR_RPMS}"/free/fedora/rpmfusion-free-release-"${RELEASE}".noarch.rpm
-curl -Lo /tmp/rpm-repos/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm "${RPMFUSION_MIRROR_RPMS}"/nonfree/fedora/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm
+# Parallelize curl downloads
+pids=()
 
-curl -Lo /etc/yum.repos.d/_copr_ublue-os_staging.repo https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${RELEASE}"/ublue-os-staging-fedora-"${RELEASE}".repo
-curl -Lo /etc/yum.repos.d/_copr_kylegospo_oversteer.repo https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-"${RELEASE}"/kylegospo-oversteer-fedora-"${RELEASE}".repo
-curl -Lo /etc/yum.repos.d/_copr_ublue-os-akmods.repo https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-"${RELEASE}"/ublue-os-akmods-fedora-"${RELEASE}".repo
+curl -Lo /tmp/rpm-repos/rpmfusion-free-release-"${RELEASE}".noarch.rpm "${RPMFUSION_MIRROR_RPMS}"/free/fedora/rpmfusion-free-release-"${RELEASE}".noarch.rpm &
+pids+=($!)
 
-curl -Lo /etc/yum.repos.d/negativo17-fedora-multimedia.repo https://negativo17.org/repos/fedora-multimedia.repo
+curl -Lo /tmp/rpm-repos/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm "${RPMFUSION_MIRROR_RPMS}"/nonfree/fedora/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm &
+pids+=($!)
+
+curl -Lo /etc/yum.repos.d/_copr_ublue-os_staging.repo https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${RELEASE}"/ublue-os-staging-fedora-"${RELEASE}".repo &
+pids+=($!)
+
+curl -Lo /etc/yum.repos.d/_copr_kylegospo_oversteer.repo https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-"${RELEASE}"/kylegospo-oversteer-fedora-"${RELEASE}".repo &
+pids+=($!)
+
+curl -Lo /etc/yum.repos.d/_copr_ublue-os-akmods.repo https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-"${RELEASE}"/ublue-os-akmods-fedora-"${RELEASE}".repo &
+pids+=($!)
+
+curl -Lo /etc/yum.repos.d/negativo17-fedora-multimedia.repo https://negativo17.org/repos/fedora-multimedia.repo &
+pids+=($!)
+
+for pid in "${pids[@]}"; do
+    wait "$pid"
+done
 
 rpm-ostree install \
     /tmp/rpm-repos/*.rpm \

--- a/tests/test_fedora_atomic_failure.sh
+++ b/tests/test_fedora_atomic_failure.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -u
+
+# Mock rpm
+rpm() {
+    if [[ "$1" == "-E" ]]; then
+        echo "39"
+    elif [[ "$1" == "-qa" ]]; then
+        echo "kernel-6.8.9-300.fc39.x86_64"
+    else
+        echo "rpm mock called with: $@" >&2
+    fi
+}
+export -f rpm
+
+# Mock rpm-ostree
+rpm-ostree() {
+    echo "rpm-ostree mock called with: $@" >&2
+}
+export -f rpm-ostree
+
+# Mock curl that fails for specific URL
+curl() {
+    echo "curl mock called with: $@" >&2
+    # Fail if the URL contains "rpmfusion"
+    if [[ "$@" == *"rpmfusion"* ]]; then
+        echo "Simulating failure for rpmfusion" >&2
+        return 1
+    fi
+    sleep 0.1
+}
+export -f curl
+
+echo "Running script expecting failure..."
+# We expect the script to fail, so we negate the exit code logic
+if bash files/scripts/fedora-atomic-repos.sh; then
+    echo "FAILURE: Script succeeded but should have failed."
+    exit 1
+else
+    echo "SUCCESS: Script failed as expected."
+fi


### PR DESCRIPTION
Parallelized `curl` downloads in `files/scripts/fedora-atomic-repos.sh` to improve build performance.
Added a regression test `tests/test_fedora_atomic_failure.sh` to ensure the script still fails correctly if a download fails.

Measured improvement:
- Baseline: ~3092ms (simulated with 0.5s latency per call)
- Optimized: ~547ms
- Speedup: ~5.6x in the simulated scenario (bounded by the longest single download).

---
*PR created automatically by Jules for task [2947570683408815681](https://jules.google.com/task/2947570683408815681) started by @sukarn-m*