### PR TITLE
security: Fix insecure repository configuration download in fedora-atomic-repos.sh

### DIFF
--- a/files/scripts/fedora-atomic-repos.sh
+++ b/files/scripts/fedora-atomic-repos.sh
@@ -13,11 +13,11 @@ mkdir -p /tmp/rpm-repos
 curl -Lo /tmp/rpm-repos/rpmfusion-free-release-"${RELEASE}".noarch.rpm "${RPMFUSION_MIRROR_RPMS}"/free/fedora/rpmfusion-free-release-"${RELEASE}".noarch.rpm
 curl -Lo /tmp/rpm-repos/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm "${RPMFUSION_MIRROR_RPMS}"/nonfree/fedora/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm
 
-curl -Lo /etc/yum.repos.d/_copr_ublue-os_staging.repo https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${RELEASE}"/ublue-os-staging-fedora-"${RELEASE}".repo
-curl -Lo /etc/yum.repos.d/_copr_kylegospo_oversteer.repo https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-"${RELEASE}"/kylegospo-oversteer-fedora-"${RELEASE}".repo
-curl -Lo /etc/yum.repos.d/_copr_ublue-os-akmods.repo https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-"${RELEASE}"/ublue-os-akmods-fedora-"${RELEASE}".repo
+dnf5 config-manager addrepo --from-repofile="https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-${RELEASE}/ublue-os-staging-fedora-${RELEASE}.repo" --overwrite --save-filename="_copr_ublue-os_staging.repo"
+dnf5 config-manager addrepo --from-repofile="https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-${RELEASE}/kylegospo-oversteer-fedora-${RELEASE}.repo" --overwrite --save-filename="_copr_kylegospo_oversteer.repo"
+dnf5 config-manager addrepo --from-repofile="https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-${RELEASE}/ublue-os-akmods-fedora-${RELEASE}.repo" --overwrite --save-filename="_copr_ublue-os-akmods.repo"
 
-curl -Lo /etc/yum.repos.d/negativo17-fedora-multimedia.repo https://negativo17.org/repos/fedora-multimedia.repo
+dnf5 config-manager addrepo --from-repofile="https://negativo17.org/repos/fedora-multimedia.repo" --overwrite --save-filename="negativo17-fedora-multimedia.repo"
 
 rpm-ostree install \
     /tmp/rpm-repos/*.rpm \

--- a/tests/test_fedora_atomic_repos.sh
+++ b/tests/test_fedora_atomic_repos.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_SCRIPT="$SCRIPT_DIR/../files/scripts/fedora-atomic-repos.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+passed=0
+failed=0
+
+test_use_dnf_for_repos() {
+    echo "Running test_use_dnf_for_repos..."
+    (
+        # Mock commands
+        rpm() {
+            if [[ "$1" == "-E" && "$2" == "%fedora" ]]; then
+                echo "38"
+            elif [[ "$1" == "-qa" ]]; then
+                echo "kernel-6.2.9-300.fc38.x86_64"
+            else
+                echo "rpm called with $@"
+            fi
+        }
+        curl() {
+            # curl -Lo /path url
+            local output_file="$2"
+            echo "CALLED_CURL output=$output_file args=$@"
+            return 0
+        }
+        dnf5() {
+            echo "CALLED_DNF5 $@"
+            return 0
+        }
+        rpm-ostree() {
+            echo "CALLED_RPM_OSTREE $@"
+            return 0
+        }
+        mkdir() {
+            return 0
+        }
+        rm() {
+            return 0
+        }
+
+        # Source the script
+        # We need to ensure set -e doesn't kill the test if a mock returns non-zero, but here mocks return 0.
+        source "$TARGET_SCRIPT" 2>&1 | tee /tmp/test_output.log
+    )
+
+    # Capture the exit code of the subshell
+    local status=$?
+    if [[ $status -ne 0 ]]; then
+        echo -e "${RED}FAIL: script execution failed${NC}"
+        ((failed++))
+        return 1
+    fi
+
+    output=$(cat /tmp/test_output.log)
+
+    # Check for curl calls to /etc/yum.repos.d/
+    if echo "$output" | grep -q "CALLED_CURL output=/etc/yum.repos.d/"; then
+        echo -e "${RED}FAIL: curl was used to download a repo file${NC}"
+        # print the offending line
+        echo "$output" | grep "CALLED_CURL output=/etc/yum.repos.d/"
+        ((failed++))
+        return 1
+    fi
+
+    # Check for dnf5 config-manager calls
+    # We expect 4 repo files to be added.
+    # _copr_ublue-os_staging.repo
+    # _copr_kylegospo_oversteer.repo
+    # _copr_ublue-os-akmods.repo
+    # negativo17-fedora-multimedia.repo
+
+    expected_repos=(
+        "_copr_ublue-os_staging.repo"
+        "_copr_kylegospo_oversteer.repo"
+        "_copr_ublue-os-akmods.repo"
+        "negativo17-fedora-multimedia.repo"
+    )
+
+    local missing_repo=0
+    for repo in "${expected_repos[@]}"; do
+        if ! echo "$output" | grep -q "CALLED_DNF5 config-manager addrepo .* --save-filename=$repo"; then
+            echo -e "${RED}FAIL: dnf5 was not called for $repo${NC}"
+            missing_repo=1
+        fi
+    done
+
+    if [[ $missing_repo -eq 1 ]]; then
+        ((failed++))
+        return 1
+    fi
+
+    echo -e "${GREEN}PASS: test_use_dnf_for_repos${NC}"
+    ((passed++))
+}
+
+# Run test
+test_use_dnf_for_repos
+
+echo "----------------------------"
+echo "Tests passed: $passed"
+echo "Tests failed: $failed"
+
+if [[ $failed -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes a security vulnerability where repository configuration files were downloaded using `curl` directly to `/etc/yum.repos.d/` without verification. This pattern was identified in `files/scripts/fedora-atomic-repos.sh`.

The fix replaces `curl` with `dnf5 config-manager addrepo --from-repofile=... --save-filename=...`, which ensures proper handling of repository configuration and aligns with security best practices.

Note: The original issue description pointed to `files/scripts/ublue-update.sh`, but that file was found to be already using the secure `dnf5 config-manager` method. The vulnerability was present in `fedora-atomic-repos.sh` instead.

Added a new test `tests/test_fedora_atomic_repos.sh` to verify that `dnf5` is used for repositories and `curl` is avoided for that purpose.

---
*PR created automatically by Jules for task [15979619399139169916](https://jules.google.com/task/15979619399139169916) started by @sukarn-m*