### PR TITLE
🔒 Fix: Secure repository download in ublue-update.sh

### DIFF
--- a/files/scripts/ublue-update.sh
+++ b/files/scripts/ublue-update.sh
@@ -30,7 +30,7 @@ main() {
 
     # Fetch ublue COPR
     REPO="https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-${OS_VERSION}/ublue-os-staging-fedora-${OS_VERSION}.repo"
-    dnf5 config-manager addrepo --from-repofile="${REPO//[$'\t\r\n ']}" --overwrite
+    dnf5 config-manager addrepo --from-repofile="${REPO//[$'\t\r\n ']}" --overwrite --save-filename="ublue-os-staging-fedora-${OS_VERSION}.repo"
 
     # topgrade is REQUIRED by ublue-update to install
     #rpm-ostree install topgrade

--- a/tests/test_ublue_update.sh
+++ b/tests/test_ublue_update.sh
@@ -67,10 +67,12 @@ test_use_dnf_not_wget() {
         fi
 
         # Check if dnf5 was called with correct args
-        # Expected: dnf5 config-manager addrepo --from-repofile=... --overwrite
+        # Expected: dnf5 config-manager addrepo --from-repofile=... --overwrite --save-filename=...
         EXPECTED_REPO="https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-38/ublue-os-staging-fedora-38.repo"
-        if [[ "$output" != *"CALLED_DNF5 config-manager addrepo --from-repofile=$EXPECTED_REPO --overwrite"* ]]; then
+        EXPECTED_FILENAME="ublue-os-staging-fedora-38.repo"
+        if [[ "$output" != *"CALLED_DNF5 config-manager addrepo --from-repofile=$EXPECTED_REPO --overwrite --save-filename=$EXPECTED_FILENAME"* ]]; then
              echo -e "${RED}FAIL: dnf5 was not called correctly${NC}"
+             echo "Expected to contain: CALLED_DNF5 config-manager addrepo --from-repofile=$EXPECTED_REPO --overwrite --save-filename=$EXPECTED_FILENAME"
              echo "Output: $output"
              exit 1
         fi


### PR DESCRIPTION
This PR addresses a security concern regarding unverified repository configuration downloads in `files/scripts/ublue-update.sh`.

Although the original issue description mentioned `wget`, the current codebase uses `dnf5 config-manager`. However, it was missing the `--save-filename` flag, which is recommended for security and consistency (and used in other scripts like `fedora-atomic-repos.sh`).

This change:
1. Adds `--save-filename="ublue-os-staging-fedora-${OS_VERSION}.repo"` to the `dnf5 config-manager addrepo` command.
2. Updates the `tests/test_ublue_update.sh` test to explicitly verify that `--save-filename` is passed to `dnf5`.

This ensures that the repository file is saved with a known and expected filename, preventing potential issues with filename unpredictability or directory traversal if `dnf5` were to behave unexpectedly with arbitrary URLs.


---
*PR created automatically by Jules for task [12937509719952174770](https://jules.google.com/task/12937509719952174770) started by @sukarn-m*