### PR TITLE
Consolidate image naming scripts into a single parameterized script

### DIFF
--- a/.github/workflows/build-gnome.yml
+++ b/.github/workflows/build-gnome.yml
@@ -14,7 +14,6 @@ on:
       - ".github/workflows/*.yml"
       - "boot_menu.yml"
       - "files/theme-v/**"
-      - "files/scripts/image_name-v.sh"
       - "files/scripts/ublue-rpms.sh"
 
   workflow_dispatch: # allow manually triggering builds

--- a/files/scripts/image_name-s.sh
+++ b/files/scripts/image_name-s.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-IMAGE_DATE=$(date +%Y%m%d.%H)
-MAJOR_RELEASE_VERSION=$(grep -oP '[0-9]*' /etc/fedora-release)
-sed -i "s,^PRETTY_NAME=.*,PRETTY_NAME=\"Sukarn Linux ${MAJOR_RELEASE_VERSION}.${IMAGE_DATE}\"," /usr/lib/os-release

--- a/files/scripts/image_name-v.sh
+++ b/files/scripts/image_name-v.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-IMAGE_DATE=$(date +%Y%m%d.%H)
-MAJOR_RELEASE_VERSION=$(grep -oP '[0-9]*' /etc/fedora-release)
-sed -i "s,^PRETTY_NAME=.*,PRETTY_NAME=\"Fedora Linux ${MAJOR_RELEASE_VERSION}.${IMAGE_DATE}\"," /usr/lib/os-release

--- a/files/scripts/image_name.sh
+++ b/files/scripts/image_name.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -oue pipefail
+
+NAME="${IMAGE_DISTRO_NAME:-Sukarn Linux}"
+OS_RELEASE_FILE="${OS_RELEASE_FILE:-/usr/lib/os-release}"
+FEDORA_RELEASE_FILE="${FEDORA_RELEASE_FILE:-/etc/fedora-release}"
+
+IMAGE_DATE=$(date +%Y%m%d.%H)
+MAJOR_RELEASE_VERSION=$(grep -oP '[0-9]*' "${FEDORA_RELEASE_FILE}")
+sed -i "s,^PRETTY_NAME=.*,PRETTY_NAME=\"${NAME} ${MAJOR_RELEASE_VERSION}.${IMAGE_DATE}\"," "${OS_RELEASE_FILE}"

--- a/recipes/base-scripts.yml
+++ b/recipes/base-scripts.yml
@@ -2,7 +2,15 @@ modules:
   - type: script
     scripts:
       - nextcloud-vfs.sh
-      - image_name-s.sh
+
+  - type: script
+    env:
+      IMAGE_DISTRO_NAME: "Sukarn Linux"
+    scripts:
+      - image_name.sh
+
+  - type: script
+    scripts:
       - nas.sh
 #      - ublue-udev.sh
 #      - canon-lbp2900.sh

--- a/recipes/image-budgie.yml
+++ b/recipes/image-budgie.yml
@@ -51,6 +51,11 @@ modules:
   - type: script
     scripts:
       - laptop-overrides.sh
-      - image_name-v.sh
+
+  - type: script
+    env:
+      IMAGE_DISTRO_NAME: "Fedora Linux"
+    scripts:
+      - image_name.sh
 
   - from-file: base-last-steps.yml

--- a/recipes/image-cosmic.yml
+++ b/recipes/image-cosmic.yml
@@ -56,6 +56,11 @@ modules:
   - type: script
     scripts:
       - laptop-overrides.sh
-      - image_name-s.sh
+
+  - type: script
+    env:
+      IMAGE_DISTRO_NAME: "Sukarn Linux"
+    scripts:
+      - image_name.sh
 
   - from-file: base-last-steps.yml

--- a/tests/test_image_name.sh
+++ b/tests/test_image_name.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Test script for image_name.sh
+
+# Create temp files
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+OS_RELEASE_FILE="$TMP_DIR/os-release"
+FEDORA_RELEASE_FILE="$TMP_DIR/fedora-release"
+
+# Populate temp files
+echo "Fedora release 39 (Thirty Nine)" > "$FEDORA_RELEASE_FILE"
+echo 'PRETTY_NAME="Fedora Linux 39 (Workstation Edition)"' > "$OS_RELEASE_FILE"
+
+# Export variables for the script
+export OS_RELEASE_FILE
+export FEDORA_RELEASE_FILE
+
+# Test 1: Default behavior (Sukarn Linux)
+export IMAGE_DISTRO_NAME="Sukarn Linux"
+bash files/scripts/image_name.sh
+
+# Check if file was updated
+if grep -q "Sukarn Linux 39" "$OS_RELEASE_FILE"; then
+    echo "Test 1 Passed: Sukarn Linux found"
+else
+    echo "Test 1 Failed: Sukarn Linux not found in $(cat "$OS_RELEASE_FILE")"
+    exit 1
+fi
+
+# Reset file
+echo 'PRETTY_NAME="Fedora Linux 39 (Workstation Edition)"' > "$OS_RELEASE_FILE"
+
+# Test 2: Custom behavior (Fedora Linux)
+export IMAGE_DISTRO_NAME="Fedora Linux"
+bash files/scripts/image_name.sh
+
+# Check if file was updated
+if grep -q "Fedora Linux 39" "$OS_RELEASE_FILE"; then
+    echo "Test 2 Passed: Fedora Linux found"
+else
+    echo "Test 2 Failed: Fedora Linux not found in $(cat "$OS_RELEASE_FILE")"
+    exit 1
+fi
+
+echo "All tests passed!"


### PR DESCRIPTION
Consolidate image naming scripts into a single parameterized script

- Replaced `files/scripts/image_name-s.sh` and `files/scripts/image_name-v.sh` with `files/scripts/image_name.sh`.
- The new script uses the `IMAGE_DISTRO_NAME` environment variable to determine the distribution name (defaulting to "Sukarn Linux").
- Updated `recipes/base-scripts.yml`, `recipes/image-cosmic.yml`, and `recipes/image-budgie.yml` to use the new script with the appropriate environment variable.
- Added a test script `tests/test_image_name.sh` to verify the functionality.
- Updated `.github/workflows/build-gnome.yml` to remove the reference to the deleted file.

---
*PR created automatically by Jules for task [4769650668505320775](https://jules.google.com/task/4769650668505320775) started by @sukarn-m*