### PR TITLE
🔒 Enforce secure repository verification with dnf5

### DIFF
--- a/files/scripts/ublue-update.sh
+++ b/files/scripts/ublue-update.sh
@@ -13,6 +13,11 @@ set_config_value() {
 }
 
 main() {
+    if ! command -v dnf5 &> /dev/null; then
+        echo "dnf5 is required for secure repository verification"
+        exit 1
+    fi
+
     # Check if ublue-os-update-services rpm is installed, these services conflict with ublue-update
     if rpm -q ublue-os-update-services > /dev/null; then
         rpm-ostree override remove ublue-os-update-services

--- a/tests/test_ublue_update.sh
+++ b/tests/test_ublue_update.sh
@@ -90,6 +90,54 @@ test_use_dnf_not_wget() {
 
 test_use_dnf_not_wget
 
+test_dnf5_missing() {
+    echo "Running test_dnf5_missing..."
+    (
+        # Mock commands
+        rpm() {
+            return 1
+        }
+        # Mock command to simulate dnf5 missing
+        command() {
+             if [[ "$1" == "-v" && "$2" == "dnf5" ]]; then
+                 return 1
+             fi
+             # Fallback for other commands if needed, or just succeed
+             return 0
+        }
+
+        # Define OS_VERSION
+        export OS_VERSION="38"
+
+        # Source the script
+        source "$UBLUE_UPDATE_SH"
+
+        # Run main
+        ret=0
+        output=$(main 2>&1) || ret=$?
+
+        if [[ $ret -eq 1 && "$output" == *"dnf5 is required for secure repository verification"* ]]; then
+             exit 0
+        else
+             echo -e "${RED}FAIL: Expected exit 1 and error message.${NC}"
+             echo "Got exit $ret"
+             echo "Output: $output"
+             exit 1
+        fi
+    )
+
+    local status=$?
+    if [[ $status -eq 0 ]]; then
+        echo -e "${GREEN}PASS: test_dnf5_missing${NC}"
+        ((passed++))
+    else
+        echo -e "${RED}FAIL: test_dnf5_missing (status $status)${NC}"
+        ((failed++))
+    fi
+}
+
+test_dnf5_missing
+
 echo "----------------------------"
 echo "Tests passed: $passed"
 echo "Tests failed: $failed"


### PR DESCRIPTION
The `files/scripts/ublue-update.sh` script is critical for system updates and relies on `dnf5 config-manager` to securely add the ublue-os staging repository. To prevent any possibility of running without this secure tool (which verifies repository configuration integrity), this PR adds a mandatory check for `dnf5` availability at the start of the script.

This change:
1. Adds a `command -v dnf5` check in `main()`.
2. Exits with a clear error message if `dnf5` is missing.
3. Adds a new test case `test_dnf5_missing` to `tests/test_ublue_update.sh` to verify this behavior.
4. Ensures that the script fails securely (fail-closed) rather than crashing or attempting fallback.

This reinforces the security posture by explicitly enforcing the use of the verified repository configuration method.

---
*PR created automatically by Jules for task [10915578562356526352](https://jules.google.com/task/10915578562356526352) started by @sukarn-m*