### PR TITLE
🔒 [security] fix unquoted variables in generate-ssh-certificate.sh

### DIFF
--- a/files/nas/usr/bin/generate-ssh-certificate.sh
+++ b/files/nas/usr/bin/generate-ssh-certificate.sh
@@ -3,13 +3,13 @@
 nas_mount=/var/mnt/nas
 
 user_string=$(grep 1000:1000 /etc/passwd) #Look for user with UID and GID of 1000
-IFS=':' user_array=($user_string) #Split by :
+IFS=':' read -r -a user_array <<< "$user_string" #Split by :
 USERNAME=${user_array[0]} #Set username
 HOMEDIR=${user_array[5]} #Set home directory
 
-EXPIRY_DATE=$(/usr/bin/ssh-keygen -Lf $HOMEDIR/.ssh/id_ed25519-cert.pub | /usr/bin/grep Valid | /usr/bin/sed -e 's/T[0-9\:]\+//g' -e 's/^\ \+Valid\:\ from\ [0-9]\+\-[0-9]\+\-[0-9]\+\ to\ //')
-DAYS_UNTIL_EXPIRY=$(( ($(date --date=$EXPIRY_DATE +%s) - $(date +%s))/(60*60*24) ))
-DAYS_UNTIL_RENEWAL=$(( $DAYS_UNTIL_EXPIRY - 365 ))
+EXPIRY_DATE=$(/usr/bin/ssh-keygen -Lf "$HOMEDIR/.ssh/id_ed25519-cert.pub" | /usr/bin/grep Valid | /usr/bin/sed -e 's/T[0-9\:]\+//g' -e 's/^\ \+Valid\:\ from\ [0-9]\+\-[0-9]\+\-[0-9]\+\ to\ //')
+DAYS_UNTIL_EXPIRY=$(( ($(date --date="$EXPIRY_DATE" +%s) - $(date +%s))/(60*60*24) ))
+DAYS_UNTIL_RENEWAL=$(( DAYS_UNTIL_EXPIRY - 365 ))
 
 echo "$DAYS_UNTIL_RENEWAL days left until certificate renewal."
 
@@ -17,22 +17,22 @@ if [ "$DAYS_UNTIL_RENEWAL" -lt "0" ]
 then
 	echo "Trying to renew the certificate."
 	HOSTNAME=$(/usr/bin/hostnamectl hostname)
-	/usr/bin/mkdir -p $nas_mount/$HOSTNAME/ssh
-	/usr/bin/cp $HOMEDIR/.ssh/id_ed25519.pub $nas_mount/$HOSTNAME/ssh/$HOSTNAME.pub
+	/usr/bin/mkdir -p "$nas_mount/$HOSTNAME/ssh"
+	/usr/bin/cp "$HOMEDIR/.ssh/id_ed25519.pub" "$nas_mount/$HOSTNAME/ssh/$HOSTNAME.pub"
 	echo "Files are in place. Let the waiting games begin."
-	while [ ! -f $nas_mount/$HOSTNAME/ssh/${HOSTNAME}-cert.pub ]
+	while [ ! -f "$nas_mount/$HOSTNAME/ssh/${HOSTNAME}-cert.pub" ]
 	do
 	    /usr/bin/echo "File not found. Waiting..."
 	    /usr/bin/sleep 60
 	done
 	/usr/bin/echo "Found the file! Waiting another 5 seconds for good luck..."
 	/usr/bin/sleep 5
-	/usr/bin/cp $nas_mount/$HOSTNAME/ssh/${HOSTNAME}-cert.pub $HOMEDIR/.ssh/id_ed25519-cert.pub
-	/usr/bin/rm -r $nas_mount/$HOSTNAME/ssh
-	/usr/bin/chcon -t ssh_home_t $HOMEDIR/.ssh/id_ed25519-cert.pub
-	/usr/bin/chown $USERNAME:$USERNAME $HOMEDIR/.ssh/id_ed25519-cert.pub
-	EXPIRY_DATE=$(/usr/bin/ssh-keygen -Lf $HOMEDIR/.ssh/id_ed25519-cert.pub | /usr/bin/grep Valid | /usr/bin/sed -e 's/T[0-9\:]\+//g' -e 's/^\ \+Valid\:\ from\ [0-9]\+\-[0-9]\+\-[0-9]\+\ to\ //')
-	DAYS_UNTIL_EXPIRY=$(( ($(date --date=$EXPIRY_DATE +%s) - $(date +%s))/(60*60*24) ))
+	/usr/bin/cp "$nas_mount/$HOSTNAME/ssh/${HOSTNAME}-cert.pub" "$HOMEDIR/.ssh/id_ed25519-cert.pub"
+	/usr/bin/rm -r "$nas_mount/$HOSTNAME/ssh"
+	/usr/bin/chcon -t ssh_home_t "$HOMEDIR/.ssh/id_ed25519-cert.pub"
+	/usr/bin/chown "$USERNAME:$USERNAME" "$HOMEDIR/.ssh/id_ed25519-cert.pub"
+	EXPIRY_DATE=$(/usr/bin/ssh-keygen -Lf "$HOMEDIR/.ssh/id_ed25519-cert.pub" | /usr/bin/grep Valid | /usr/bin/sed -e 's/T[0-9\:]\+//g' -e 's/^\ \+Valid\:\ from\ [0-9]\+\-[0-9]\+\-[0-9]\+\ to\ //')
+	DAYS_UNTIL_EXPIRY=$(( ($(date --date="$EXPIRY_DATE" +%s) - $(date +%s))/(60*60*24) ))
 	echo "New certificate is valid until $EXPIRY_DATE"
 else
 	echo "Current certificate is valid until $EXPIRY_DATE"


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR fixes a security vulnerability in `files/nas/usr/bin/generate-ssh-certificate.sh` where variables used in file system operations (like `rm -r`, `mkdir`, and `cp`) were not properly quoted.

### ⚠️ Risk: The potential impact if left unfixed
If left unfixed, an attacker who can influence variables like `HOSTNAME` or `HOMEDIR` could potentially trigger path traversal or unintended file deletion. Even in non-malicious scenarios, paths containing spaces would cause the script to fail or behave unpredictably (e.g., `rm -r /mnt/nas/my host/ssh` would attempt to remove `/mnt/nas/my`, `host`, and `/ssh` separately).

### 🛡️ Solution: How the fix addresses the vulnerability
The fix wraps all identified variables in double quotes, ensuring they are treated as single arguments by the shell. Additionally, it improves the robustness of the script by using `read -r -a` for parsing `/etc/passwd` to prevent unintended globbing or word splitting during array assignment.

---
*PR created automatically by Jules for task [18321089656592082234](https://jules.google.com/task/18321089656592082234) started by @sukarn-m*