### PR TITLE
Fix desktop image build failure related to `nvidia-modeset.conf`

### DIFF
--- a/files/scripts/kernel.sh
+++ b/files/scripts/kernel.sh
@@ -488,7 +488,6 @@ function install_nvidia_packages () {
     semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
     
     # Universal Blue specific Initramfs fixes
-    cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
     # we must force driver load to fix black screen on boot for nvidia desktops
     sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
     # as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration


### PR DESCRIPTION
Removed the failing `cp` command for `nvidia-modeset.conf` in `files/scripts/kernel.sh`. The upstream no longer provides this file, and the required kernel arguments are already set using the `kargs` module in the desktop recipe.

---
*PR created automatically by Jules for task [2799754170151871243](https://jules.google.com/task/2799754170151871243) started by @sukarn-m*