### PR TITLE
🧹 [CI] Disable rechunk in PR builds

### DIFF
--- a/.github/workflows/build-gnome.yml
+++ b/.github/workflows/build-gnome.yml
@@ -49,7 +49,7 @@ jobs:
           # Optional flags
           use_unstable_cli: false
 #          squash: true
-          rechunk: true
+          rechunk: ${{ github.event_name != 'pull_request' }}
       # start device-specific builds
 #      - name: Build Device Specific Images
 #        run: |

--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -46,5 +46,5 @@ jobs:
           
           # Optional flags
           use_unstable_cli: false
-          rechunk: true
+          rechunk: ${{ github.event_name != 'pull_request' }}
 #          squash: true


### PR DESCRIPTION
* Updated `.github/workflows/build-gnome.yml` to set `rechunk` dynamically.
* Updated `.github/workflows/build-others.yml` to set `rechunk` dynamically.
This prevents the time-consuming `rechunk` process from running during Pull Request checks, while maintaining the required behavior for other events.

---
*PR created automatically by Jules for task [15598706367548785965](https://jules.google.com/task/15598706367548785965) started by @sukarn-m*